### PR TITLE
Png support

### DIFF
--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -1,0 +1,221 @@
+{
+  "advanced.exif.label": {
+    "message": "Kopiuj dane EXIF"
+  },
+  "advanced.gps.label": {
+    "message": "Kopiuj dane GPS"
+  },
+  "advanced.label": {
+    "message": "Zaawansowane"
+  },
+  "advanced.logenabled.label": {
+    "message": "Loguj do Konsoli Błedów"
+  },
+  "advanced.orient.label": {
+    "message": "Automatycznie obróć obrazki"
+  },
+  "advanced.resample.label": {
+    "message": "Ponowne próbkowanie obrazów za pomocą javascript"
+  },
+  "advanced.resizeonsend.false": {
+    "message": "przy dodawaniu załącznika"
+  },
+  "advanced.resizeonsend.label": {
+    "message": "Proponuj zmianę rozmiaru obrazów:"
+  },
+  "advanced.resizeonsend.true": {
+    "message": "przy wysyłaniu wiadomości"
+  },
+  "cancel": {
+    "message": "Anuluj"
+  },
+  "changelog.button.accesskey": {
+    "message": "A"
+  },
+  "changelog.button.label": {
+    "message": "Co się zmieniło?"
+  },
+  "config.title": {
+    "message": "Shrunked Image Resizer - konfiguracja"
+  },
+  "context.plural": {
+    "message": "Zmień rozmiar tych obrazów…"
+  },
+  "context.single": {
+    "message": "Zmień rozmiar tego obrazu…"
+  },
+  "custom.label": {
+    "message": "Niestandardowy"
+  },
+  "custom.pixels": {
+    "message": "px"
+  },
+  "defaults.label": {
+    "message": "Domyślne ustawienia"
+  },
+  "defaults.quality.better": {
+    "message": "Lepsza jakość"
+  },
+  "defaults.quality.label": {
+    "message": "Ustawienia enkodera JPEG:"
+  },
+  "defaults.quality.smaller": {
+    "message": "Mniejszy rozmiar pliku"
+  },
+  "dimensions": {
+    "message": "$WIDTH$ px × $HEIGHT$ px",
+    "placeholders": {
+      "height": {
+        "content": "$2",
+        "example": "600"
+      },
+      "width": {
+        "content": "$1",
+        "example": "800"
+      }
+    }
+  },
+  "donate.button.accesskey": {
+    "message": "W"
+  },
+  "donate.button.label": {
+    "message": "Wesprzyj"
+  },
+  "donate.notification": {
+    "message": "Shrunked Image Resizer został zaktualizowany do wersji $VERSION$. Shrunked jest darmowy, ale twoje wsparcie jest mile widziane!",
+    "placeholders": {
+      "version": {
+        "content": "$1",
+        "example": "5.0"
+      }
+    }
+  },
+  "extensionDescription": {
+    "message": "Zmniejsz rozmiar obrazów, żeby szybciej je wysłać w wiadomości lub wgrać na serwer."
+  },
+  "extensionName": {
+    "message": "Shrunked Image Resizer"
+  },
+  "height.label": {
+    "message": "Wysokość:"
+  },
+  "large.label": {
+    "message": "1200 px"
+  },
+  "maxsize.label": {
+    "message": "Maksymalny rozmiar obrazów:"
+  },
+  "medium.label": {
+    "message": "800 px"
+  },
+  "minsize.label": {
+    "message": "Nie modyfikuj obrazów o rozmiarze pliku mniejszym niż:"
+  },
+  "no.accesskey": {
+    "message": "N"
+  },
+  "no.label": {
+    "message": "Nie"
+  },
+  "noresize.label": {
+    "message": "Oryginał"
+  },
+  "ok": {
+    "message": "OK"
+  },
+  "options.savedefault.label": {
+    "message": "Zapisz jako domyślne ustawienia"
+  },
+  "options.title": {
+    "message": "Shrunked Image Resizer - ustawienia"
+  },
+  "preview.label": {
+    "message": "Podgląd:"
+  },
+  "preview.next.tooltip": {
+    "message": "Następny obraz"
+  },
+  "preview.notresized": {
+    "message": "Obraz niezmieniony"
+  },
+  "preview.originalfilesize": {
+    "message": "Oryginalny rozmiar pliku: $SIZE$",
+    "placeholders": {
+      "size": {
+        "content": "$1",
+        "example": "4.3 MB"
+      }
+    }
+  },
+  "preview.originalsize": {
+    "message": "Oryginalne wymiary obrazu: $WIDTH$ px × $HEIGHT$ px",
+    "placeholders": {
+      "height": {
+        "content": "$2",
+        "example": "600"
+      },
+      "width": {
+        "content": "$1",
+        "example": "800"
+      }
+    }
+  },
+  "preview.previous.tooltip": {
+    "message": "Poprzedni obraz"
+  },
+  "preview.resized": {
+    "message": "Nowe wymiary obrazu: $WIDTH$ px × $HEIGHT$ px",
+    "placeholders": {
+      "height": {
+        "content": "$2",
+        "example": "600"
+      },
+      "width": {
+        "content": "$1",
+        "example": "800"
+      }
+    }
+  },
+  "preview.resizedfilesize": {
+    "message": "Szacowany nowy rozmiar pliku: $SIZE$",
+    "placeholders": {
+      "size": {
+        "content": "$1",
+        "example": "4.3 MB"
+      }
+    }
+  },
+  "preview.resizedfilesize.estimating": {
+    "message": "Szacowanie nowego rozmiaru pliku…"
+  },
+  "question.plural": {
+    "message": "Zmienić rozmiar tych obrazów?"
+  },
+  "question.single": {
+    "message": "Zmienić rozmiar tego obrazu?"
+  },
+  "small.label": {
+    "message": "500 px"
+  },
+  "status.resizing": {
+    "message": "Zmieniam rozmiar obrazu…;Zmieniam rozmiar obrazów…"
+  },
+  "unit.bytes": {
+    "message": "B"
+  },
+  "unit.kilobytes": {
+    "message": "kB"
+  },
+  "unit.megabytes": {
+    "message": "MB"
+  },
+  "width.label": {
+    "message": "Szerokość:"
+  },
+  "yes.accesskey": {
+    "message": "T"
+  },
+  "yes.label": {
+    "message": "Tak"
+  }
+}

--- a/api/shrunked.js
+++ b/api/shrunked.js
@@ -57,14 +57,14 @@ var shrunked = class extends ExtensionCommon.ExtensionAPI {
             let shouldShow = false;
             if (target.nodeName == "IMG") {
               console.log("Context menu on an <IMG>");
-              if (target.src.startsWith("data:image/jpeg;")) {
+              if (imageIsAccepted(target.src)) {
                 if (target.width > 500 || target.height > 500) {
                   shouldShow = true;
                 } else {
                   console.log("Not resizing - image is too small");
                 }
               } else {
-                console.log("Not resizing - image is not JPEG");
+                console.log("Not resizing - image is not JPEG / PNG");
               }
             }
 
@@ -97,10 +97,8 @@ var shrunked = class extends ExtensionCommon.ExtensionAPI {
               let reader = new FileReader();
               reader.onloadend = function() {
                 let dataURL = reader.result;
-                dataURL =
-                  "data:image/jpeg;filename=" +
-                  encodeURIComponent(destFile.name) +
-                  dataURL.substring(15);
+                let headerIndexEnd = dataURL.indexOf(";");
+                dataURL = reader.result.substring(0, headerIndexEnd) + ";filename=" + encodeURIComponent(destFile.name) + dataURL.substring(headerIndexEnd);
                 resolve(dataURL);
               };
               reader.readAsDataURL(destFile);
@@ -129,8 +127,7 @@ var shrunked = class extends ExtensionCommon.ExtensionAPI {
               }
               let attachment = items[i].attachment;
               if (
-                attachment.url.startsWith("data:image/jpeg;") ||
-                /\.jpe?g$/i.test(attachment.url)
+                imageIsAccepted(attachment.url)
               ) {
                 indicies.push(i);
               }
@@ -138,7 +135,7 @@ var shrunked = class extends ExtensionCommon.ExtensionAPI {
 
             attachmentMenuItem.hidden = !indicies.length;
             if (!indicies.length) {
-              console.log("Not resizing - no attachments were JPEG and large enough");
+              console.log("Not resizing - no attachments were JPEG/PNG and large enough");
             } else if (indicies.length == 1) {
               attachmentMenuItem.label = localeData.localizeMessage("context.single");
             } else {
@@ -347,3 +344,10 @@ var shrunked = class extends ExtensionCommon.ExtensionAPI {
     }
   }
 };
+
+function imageIsAccepted(url) {
+  let src = url.toLowerCase();
+  let isJPEG = src.startsWith("data:image/jpeg") || src.endsWith(".jpg") || src.endsWith(".jpeg");
+  let isPNG = src.startsWith("data:image/png") || src.endsWith(".png");
+  return isJPEG | isPNG;
+}

--- a/background.js
+++ b/background.js
@@ -1,7 +1,7 @@
 var tabMap = new Map();
 
 async function shouldResize(attachment, checkSize = true) {
-  if (!attachment.name.toLowerCase().match(/\.jpe?g$/)) {
+  if (!attachment.name.toLowerCase().match(/((\.jpe?g)|(\.png))$/)) {
     return false;
   }
   if (!checkSize) {

--- a/compose_script.js
+++ b/compose_script.js
@@ -58,8 +58,8 @@ async function maybeResizeInline(target) {
         console.log("Not resizing - image already has shrunked attribute");
         return;
       }
-      if (!imageIsJPEG(target)) {
-        console.log("Not resizing - image is not JPEG");
+      if (!imageIsAccepted(target)) {
+        console.log("Not resizing - image is not JPEG / PNG");
         return;
       }
       if (target.width < 500 && target.height < 500) {
@@ -106,9 +106,10 @@ async function maybeResizeInline(target) {
         let reader = new FileReader();
         reader.onloadend = function() {
           let dataURL = reader.result;
-          dataURL =
-            "data:image/jpeg;filename=" + encodeURIComponent(destFile.name) + dataURL.substring(15);
-          resolve(dataURL);
+                    let headerIndexEnd = dataURL.indexOf(";");
+                    dataURL =
+                        reader.result.substring(0, headerIndexEnd) + ";filename=" + encodeURIComponent(destFile.name) + dataURL.substring(headerIndexEnd);
+                    resolve(dataURL);
         };
         reader.readAsDataURL(destFile);
       });
@@ -128,7 +129,9 @@ async function maybeResizeInline(target) {
   }
 }
 
-function imageIsJPEG(image) {
-  let src = image.src.toLowerCase();
-  return src.startsWith("data:image/jpeg") || src.endsWith(".jpg");
+function imageIsAccepted(image) {
+    let src = image.src.toLowerCase();
+    let isJPEG = src.startsWith("data:image/jpeg") || src.endsWith(".jpg") || src.endsWith(".jpeg");
+    let isPNG = src.startsWith("data:image/png") || src.endsWith(".png");
+    return isJPEG | isPNG;
 }

--- a/modules/ShrunkedImage.jsm
+++ b/modules/ShrunkedImage.jsm
@@ -11,6 +11,7 @@ var XHTMLNS = "http://www.w3.org/1999/xhtml";
 function ShrunkedImage(source, maxWidth, maxHeight, quality, options) {
   this.maxWidth = maxWidth;
   this.maxHeight = maxHeight;
+  this.imageFormat="image/jpeg";
   this.quality = quality;
   this.options = {
     exif: true,
@@ -38,7 +39,7 @@ function ShrunkedImage(source, maxWidth, maxHeight, quality, options) {
       if (match) {
         this.basename = match[1];
       } else {
-        match = /\/([\w.-]+\.jpg)$/i.exec(this.sourceURI.spec);
+        match = /\/([\w.-]+\.((png)|(jpe?g)))$/i.exec(this.sourceURI.spec);
         if (match) {
           this.basename = match[1];
         }
@@ -53,6 +54,10 @@ function ShrunkedImage(source, maxWidth, maxHeight, quality, options) {
     this.basename = source.name;
   }
 
+  if(this.basename.endsWith(".png"))
+  {
+    this.imageFormat="image/png";
+  }
   if (!this.sourceURI) {
     throw new Error("Unexpected source passed to ShrunkedImage");
   }
@@ -75,7 +80,7 @@ ShrunkedImage.prototype = {
     }
 
     let blob = await this.getBytes(canvas);
-    return new File([blob], this.basename, { type: "image/jpeg" });
+    return new File([blob], this.basename, { type: this.imageFormat });
   },
   async readExifData() {
     try {
@@ -186,8 +191,8 @@ ShrunkedImage.prototype = {
             reject(ex);
           }
         },
-        "image/jpeg",
-        this.quality / 100
+        this.imageFormat,
+        (this.imageFormat=="image/jpeg")?(this.quality / 100):null
       );
     });
   },


### PR DESCRIPTION
Added support for resizing of PNG files. 
File format is preserved (pngs are resized and saved as pngs, jpegs are resized and saved as jpegs).
Both inline images and attached images work (TB 102.4.2).